### PR TITLE
Add Help Message with Usage Information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local Test Files
+.gitteam
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -86,3 +86,4 @@ This project is licensed under the [MIT License][2]
 [thatiane]: https://github.com/thatiane
 [hegde5]: https://github.com/hegde5
 [Detril]: https://github.com/Detril
+[JayWelborn]:https://github.com/JayWelborn

--- a/gcommit
+++ b/gcommit
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import argparse
 import os
 import sys
 import tempfile
@@ -39,12 +40,11 @@ def read_team():
         raise IOError('Could not find .gitteam file')
 
 
-def filter_team(team):
-    selected = sys.argv[1:]
+def filter_team(team, initials):
     filtered = {}
 
     error = None
-    for mem in selected:
+    for mem in initials:
         if mem in team:
             filtered[mem] = team[mem]
         else:
@@ -97,9 +97,20 @@ def main():
     If there's no .gitteam file, then a regular commit is done
     If there's an argument-format error, then a ValueError is raised
     """
+
+    # Define expected command line arguments, and parse arguments given
+    parser = argparse.ArgumentParser(
+        description='GCommit is a git-plugin that allows commits to be signed \
+                    by more than one person -- pair and mob programming \
+                    reality.')
+    parser.add_argument(
+        'initials', metavar='[INITIALS]', type=str, nargs='+',
+        help='The intials of each developer defined in .gitteam')
+    args = parser.parse_args()
+
     try:
         team = read_team()
-        group = filter_team(team)
+        group = filter_team(team, args.initials)
         group_commit(group)
     except ValueError as ve:
         print(ve)


### PR DESCRIPTION
## Proposed Changes

Add the option to run gcommit -h or --h to get a help message explaining
expected usage of GCommit.

Refactor argument parsing to use python's built-in argparse rather than
accessing sys.argv directly. This is helpful because the -h or --help
options would be read as part of sys.argv if they were present. Argparse
also displays a help message on improper usage (e.g. using gcommit with
no developer initials).

Signed-off-by: "Jay Welborn <jay@jaywelborn.com>"

## Issue

Fixes #3 

