### PR TITLE
Support for --all command to include entire team

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Many thanks to all contributors!
 |[Pedro][pedro823] Pereira          |<img src="https://avatars2.githubusercontent.com/u/7110169?s=200&v=4"  alt="Pedro Pereira"/> |
 |[Jay][JayWelborn] Welborn          |<img src="https://avatars1.githubusercontent.com/u/20888363?s=200&v=4" alt="Jay Welborn"/> |
 |[Leandro][Leandrigues] Rodrigues   |<img src="https://avatars1.githubusercontent.com/u/39068024?s=460&v=4" alt="Leandro Rodrigues" width="200"/> |
-|[Parth][ParthPratim] Pratim        |<img src="https://avatars1.githubusercontent.com/u/30770796?s=460&v=4"  alt="ParthPratim"/> |
+|[Parth][ParthPratim] Pratim        |<img src="https://avatars1.githubusercontent.com/u/30770796?s=460&v=4"  alt="ParthPratim" width="200"/> |
 
 
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Signed-off-by: Jane Doe <jane.doe@example.com>
 Signed-off-by: João Daniel <jotaf.daniel@gmail.com>
 ```
 
+To add all the members of your team to the commit, you can use the following command
+
+```bash
+git gcommit --all
+```
 
 ## Contributing
 
@@ -79,9 +84,7 @@ Many thanks to all contributors!
 |[Pedro][pedro823] Pereira          |<img src="https://avatars2.githubusercontent.com/u/7110169?s=200&v=4"  alt="Pedro Pereira"/> |
 |[Jay][JayWelborn] Welborn          |<img src="https://avatars1.githubusercontent.com/u/20888363?s=200&v=4" alt="Jay Welborn"/> |
 |[Leandro][Leandrigues] Rodrigues   |<img src="https://avatars1.githubusercontent.com/u/39068024?s=460&v=4" alt="Leandro Rodrigues" width="200"/> |
-
-
-
+|[Parth][ParthPratim] Pratim        |<img src="https://avatars1.githubusercontent.com/u/30770796?s=460&v=4"  alt="ParthPratim"/> |
 
 
 
@@ -108,5 +111,4 @@ This project is licensed under the [MIT License][2]
 [pedro823]: https://github.com/pedro823
 [JayWelborn]:https://github.com/JayWelborn
 [Leandrigues]:https://github.com/Leandrigues
-
-
+[ParthPratim]:https://github.com/ParthPratim

--- a/gcommit
+++ b/gcommit
@@ -116,12 +116,16 @@ def main():
                     by more than one person -- pair and mob programming \
                     reality.')
     parser.add_argument(
-        'initials', metavar='[INITIALS]', type=str, nargs='+',
+        'initials', metavar='[INITIALS]', type=str, nargs='*',
         help='The intials of each developer defined in .gitteam')
 
     parser.add_argument(
         '--remove', '-r', metavar='[INITIALS]', type=str,
         help='Remove a member from .gitteam', dest='remotion')
+    
+    parser.add_argument(
+        '--all',action='store_true',
+        help='Add all members to team commit.', dest='addall')
 
     args = parser.parse_args()
     try:
@@ -129,6 +133,8 @@ def main():
             # Removes initials passed with --remove
             remove_member(args.remotion)
         team = read_team()
+        if(args.addall):
+            args.initials = team.keys()
         group = filter_team(team, args.initials)
         group_commit(group)
     except ValueError as ve:


### PR DESCRIPTION
Signed-off-by: Parth Pratim Chatterjee <parth27official@gmail.com>


## Proposed Changes

# Support for --all command
Adds support for --all command to include entire team into commit sign off list.
Usage :
```plain
git gcommit --all
```
## Issue

Closes/Fixes #28 

