### PR TITLE
GCommit to Git Wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Signed-off-by: Jane Doe <jane.doe@example.com>
 Signed-off-by: João Daniel <jotaf.daniel@gmail.com>
 ```
 
+To pass other ```git commit``` command line arguments to GCommit we would have to do the following :
+
+```bash
+git gcommit JAD JD --amend
+```
+where ```--ammend``` is an argument for ```git commit``` 
 
 ## Contributing
 
@@ -79,8 +85,7 @@ Many thanks to all contributors!
 |[Pedro][pedro823] Pereira          |<img src="https://avatars2.githubusercontent.com/u/7110169?s=200&v=4"  alt="Pedro Pereira"/> |
 |[Jay][JayWelborn] Welborn          |<img src="https://avatars1.githubusercontent.com/u/20888363?s=200&v=4" alt="Jay Welborn"/> |
 |[Leandro][Leandrigues] Rodrigues   |<img src="https://avatars1.githubusercontent.com/u/39068024?s=460&v=4" alt="Leandro Rodrigues" width="200"/> |
-
-
+|[Parth][ParthPratim] Pratim        |<img src="https://avatars1.githubusercontent.com/u/30770796?s=460&v=4"  alt="ParthPratim"/> |
 
 
 
@@ -108,5 +113,4 @@ This project is licensed under the [MIT License][2]
 [pedro823]: https://github.com/pedro823
 [JayWelborn]:https://github.com/JayWelborn
 [Leandrigues]:https://github.com/Leandrigues
-
-
+[ParthPratim]:https://github.com/ParthPratim

--- a/gcommit
+++ b/gcommit
@@ -124,7 +124,7 @@ def main():
         help='Remove a member from .gitteam', dest='remotion')
     
     parser.add_argument(
-        '--all',action='store_true',
+        '--sign-all',action='store_true',
         help='Add all members to team commit.', dest='addall')
     
     parser.add_argument(

--- a/gcommit
+++ b/gcommit
@@ -143,7 +143,7 @@ def main():
         if(k_args.addall):
             k_args.initials = team.keys()
             
-        if(args.exceptcomm):
+        if(k_args.exceptcomm):
             initials_ls = [k_args.exceptcomm] + k_args.initials
             for elem in initials_ls:
                 if elem in team:

--- a/gcommit
+++ b/gcommit
@@ -74,7 +74,7 @@ def remove_member(member):
     file = open(team_file, 'w')
     file.write(new_file)
     
-def group_commit(team,uk_args):
+def group_commit(team,c_args):
     initial_message = b"\n"
 
     for d in team:
@@ -100,7 +100,7 @@ def group_commit(team,uk_args):
             sys.exit()
         tf.seek(0)
         edited_message = tf.read()
-        call(["git", "commit", "-m", edited_message]+uk_args)
+        call(["git", "commit", "-m", edited_message]+c_args)
 
 
 def main():
@@ -132,29 +132,29 @@ def main():
         help='Remove member from current team commit.' , dest='exceptcomm')
 
     all_args = parser.parse_known_args()
-    k_args = all_args[0] # arguments which are detected based on above definition
-    uk_args = all_args[1] # additional arguments given by user, to be passed as it is to got commit
+    gc_args = all_args[0] # arguments which are detected based on above definition for gcommit
+    c_args = all_args[1] # additional arguments given by user, to be passed as it is to got commit
     try:
-        if(k_args.remotion):
+        if(gc_args.remotion):
             # Removes initials passed with --remove
-            remove_member(k_args.remotion)
+            remove_member(gc_args.remotion)
         team = read_team()
 
-        if(k_args.addall):
-            k_args.initials = team.keys()
+        if(gc_args.addall):
+            gc_args.initials = team.keys()
             
-        if(k_args.exceptcomm):
-            initials_ls = [k_args.exceptcomm] + k_args.initials
+        if(gc_args.exceptcomm):
+            initials_ls = [gc_args.exceptcomm] + gc_args.initials
             for elem in initials_ls:
                 if elem in team:
                     del team[elem]
                 else:
                     print("Member {} not found in .gitteam.".format(elem))
             group = filter_team(team, team.keys())
-            group_commit(group,uk_args)
+            group_commit(group,c_args)
         else:
-            group = filter_team(team, k_args.initials)
-            group_commit(group,uk_args)
+            group = filter_team(team, gc_args.initials)
+            group_commit(group,c_args)
 
     except ValueError as ve:
         print(ve)

--- a/gcommit
+++ b/gcommit
@@ -133,7 +133,7 @@ def main():
 
     all_args = parser.parse_known_args()
     gc_args = all_args[0] # arguments which are detected based on above definition for gcommit
-    c_args = all_args[1] # additional arguments given by user, to be passed as it is to got commit
+    c_args = all_args[1] # additional arguments given by user, to be passed as it is to git commit
     try:
         if(gc_args.remotion):
             # Removes initials passed with --remove

--- a/gcommit
+++ b/gcommit
@@ -74,7 +74,7 @@ def remove_member(member):
     file = open(team_file, 'w')
     file.write(new_file)
     
-def group_commit(team):
+def group_commit(team,uk_args):
     initial_message = b"\n"
 
     for d in team:
@@ -100,7 +100,7 @@ def group_commit(team):
             sys.exit()
         tf.seek(0)
         edited_message = tf.read()
-        call(["git", "commit", "-m", edited_message])
+        call(["git", "commit", "-m", edited_message]+uk_args)
 
 
 def main():
@@ -116,21 +116,23 @@ def main():
                     by more than one person -- pair and mob programming \
                     reality.')
     parser.add_argument(
-        'initials', metavar='[INITIALS]', type=str, nargs='+',
+        'initials', metavar='[INITIALS]', type=str, nargs='*',
         help='The intials of each developer defined in .gitteam')
 
     parser.add_argument(
         '--remove', '-r', metavar='[INITIALS]', type=str,
         help='Remove a member from .gitteam', dest='remotion')
 
-    args = parser.parse_args()
+    all_args = parser.parse_known_args()
+    k_args = all_args[0]
+    uk_args = all_args[1]
     try:
-        if(args.remotion):
+        if(k_args.remotion):
             # Removes initials passed with --remove
-            remove_member(args.remotion)
+            remove_member(k_args.remotion)
         team = read_team()
-        group = filter_team(team, args.initials)
-        group_commit(group)
+        group = filter_team(team, k_args.initials)
+        group_commit(group,uk_args)
     except ValueError as ve:
         print(ve)
     except OSError:


### PR DESCRIPTION
Signed-off-by: Parth Pratim Chatterjee <parth27official@gmail.com>


## Proposed Changes
This allows you to call native ```git commit``` command line options from ``` git gcommit``` Format :
```plain
git gcommit [INITIALS...] [git command line options .....]
```
Sample Usage : 
```plain
git gcommit JB MB --amend
```

## Issue

Closes/Fixes #2 

