### PR TITLE
Addding setup.py for versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ once and reference at any commit-time.
 For installation you have to run the next command:
 
 ```
-$ sudo make install
-
+$ sudo python setup.py install
 GCommit has been installed successfully
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,65 @@
+import setuptools
+import shutil
+import subprocess
+import platform
+import sys
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+def tool_on_sys(name):
+    return shutil.which(name) is not None
+
+def execute_cmd(command):
+    process = subprocess.Popen(command,
+                     stdout=subprocess.PIPE, 
+                     stderr=subprocess.PIPE)
+    return process
+
+def install_to_git():
+    process = execute_cmd(['make','install'])
+    stdout, stderr = process.communicate()
+    if stderr == b'':
+        print(bcolors.OKGREEN + "Success : {}".format(stdout.decode("utf-8") ) + bcolors.ENDC)
+    else:
+        print(bcolors.FAIL + "Failure : {}".format(stderr.decode("utf-8") ) + bcolors.ENDC)
+
+with open("README.md", "r") as fd:
+    long_description = fd.read()
+
+setuptools.setup(
+    name="GCommit", # Replace with your own username
+    version="1.0",
+    author="jooaodanieel",
+    description="GCommit is a git-plugin that eases how to commit when you need to sign \
+        for more than one person -- pair and mob programming reality.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/jooaodanieel/GCommit",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+    ],
+    py_modules=['subprocess'],
+    python_requires='>=3.6',
+    )
+
+if tool_on_sys("git"):
+    make_exe = None
+    if (tool_on_sys("make")):
+        install_to_git()
+    else:
+        print(bcolors.FAIL + "Failure : make was not found on this system. Please install Git" + bcolors.ENDC)
+else:
+    print(bcolors.FAIL + "Failure : Git was not found on this system. Please install Git" + bcolors.ENDC)
+    
+    
+
+

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,13 @@ class bcolors:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
+
+def print_err(msg):
+    print(bcolors.FAIL + "Failure : {}".format(msg) + bcolors.ENDC)
+
+def print_succ(msg):
+    print(bcolors.OKGREEN + "Success : {}".format(msg) + bcolors.ENDC)
+    
 def tool_on_sys(name):
     return shutil.which(name) is not None
 
@@ -27,10 +34,10 @@ def install_to_git():
     process = execute_cmd(['make','install'])
     stdout, stderr = process.communicate()
     if stderr == b'':
-        print(bcolors.OKGREEN + "Success : {}".format(stdout.decode("utf-8") ) + bcolors.ENDC)
+        print_succ(stdout.decode("utf-8"))
     else:
-        print(bcolors.FAIL + "Failure : {}".format(stderr.decode("utf-8") ) + bcolors.ENDC)
-
+        print_err(stderr.decode("utf-8")) 
+        
 with open("README.md", "r") as fd:
     long_description = fd.read()
 
@@ -56,9 +63,9 @@ if tool_on_sys("git"):
     if (tool_on_sys("make")):
         install_to_git()
     else:
-        print(bcolors.FAIL + "Failure : make was not found on this system. Please install Git" + bcolors.ENDC)
+        print_err("Failure : 'make' was not found on this system. Please install Git")
 else:
-    print(bcolors.FAIL + "Failure : Git was not found on this system. Please install Git" + bcolors.ENDC)
+    print_err("Failure : 'git' was not found on this system. Please install Git")
     
     
 


### PR DESCRIPTION
Signed-off-by: Parth Pratim Chatterjee <parth27official@gmail.com>


## Proposed Changes

Currently it required one to do  ```sudo make install``` for installing GCommit which does not support versioning and is not a very recommended way of shipping code.

This PR adds support for this by creating ```setup.py```.

Now it requires one to execute the following for installing :
```plain

sudo python setup.py install

```

