### PR TITLE
Support for named teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ So, for instance, a team member can be defined in `gcommit.conf.json` as follows
       "tag": "JAD"
     }
   ],
+  "namedTeams": {
+    "frontend": [ "AB", "CD" ]
+  }
   
   // ... other aspects ...
   
@@ -87,6 +90,8 @@ So, for instance, a team member can be defined in `gcommit.conf.json` as follows
 GCommit makes it easier to sign commits by providing a quick reference to a stored team member.
 The **tag** is the "quick reference".
 So make sure to inform unique tags ;)
+
+The **namedTeams** makes it possible to use pre-defined named teams that translate to a set of people
 
 2. the signature format
 
@@ -119,6 +124,13 @@ Then, after adding changes to git staging area, simply run
 ```bash
 git gcommit JOD JAD
 ```
+
+If you configured a named team you can run
+
+```bash
+git gcommit frontend
+```
+to have the same effect
 
 > in the case you want to sign with the entire team, you can simply run `git gcommit` with no arguments
 

--- a/src/nativeMain/kotlin/model/Config.kt
+++ b/src/nativeMain/kotlin/model/Config.kt
@@ -9,11 +9,13 @@ import kotlinx.serialization.Serializable
  *
  * @property team a list of [Author]
  * @property format [default: GCommit/GitHub] signing format adopted by the Code Repository platform
+ * @property namedTeams [default: null] the map of namedTeams with relative tags
  */
 @Serializable
 data class Config(
     val team: List<Author>,
-    val format: String = GCommit.GITHUB_FORMAT_LABEL
+    val format: String = GCommit.GITHUB_FORMAT_LABEL,
+    val namedTeams: NamedTeams? = null
 ) {
 
     /**
@@ -25,4 +27,16 @@ data class Config(
      * @return an [Author], if there is a match; null otherwise
      */
     operator fun get(index: String): Author? = team.find { it.tag == index }
+
+    /**
+     * Retrive point for list of [Author] via [NamedTeams]
+     *
+     * Operator to find a list of [Author] in the team by the named team; to be used with brackets `config[NamedTeams]`
+     *
+     * @param namedTeams the map of named teams with relative tags
+     * @return a list of unique [Author], if there is a match; an empty list otherwhise
+     */
+    operator fun get(namedTeams: NamedTeams): List<Author> =
+        team.filter { namedTeams.values.flatten().contains(it.tag) }.distinct()
+
 }

--- a/src/nativeMain/kotlin/model/NamedTeams.kt
+++ b/src/nativeMain/kotlin/model/NamedTeams.kt
@@ -1,0 +1,9 @@
+package model
+
+/**
+ * NamedTeams which contains tags for every named team
+ *
+ * This typealias represents the structure for the data in the configuration file regarding namedTeams object
+ *
+ */
+typealias NamedTeams = Map<String, List<String>>


### PR DESCRIPTION
## Proposed Changes

- added NamedTeams typealias
- edited Config to accept NamedTeams
- refactored createAuthorsSignatures method in GCommit
- added fetchAuthJOD JADors method to return list of Author either from NamedTeams or from tags
- added documentation


## Issue

Closes/Fixes # https://github.com/jooaodanieel/GCommit/issues/52

